### PR TITLE
Removed reference to Mozilla Science Lab in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,8 @@ lessons: ['Git', 'Python', 'Make', 'Best practices for scientific computing', 'D
   href="http://www.epcc.ed.ac.uk">EPCC</a>, as part of ARCHER. The
   workshop is in collaboration with EPCC's <a
   href="http://www.prace-project.eu/PRACE-Advanced-Training-Centres">PRACE
-  Advanced Training Centre</a> (PATC), and Software Carpentry, a <a
-  href="https://wiki.mozilla.org/ScienceLab">Mozilla Science Lab</a>
-  initiative. 
+  Advanced Training Centre</a> (PATC), and 
+  <a href="http://www.software-carpentry.org/">Software Carpentry</a>.
 </p>
 
 <p>


### PR DESCRIPTION
Corrected workshop text and added direct link to Software Carpentry as Software Carpentry is no longer a part of Mozilla Science Lab (since late 2014).
